### PR TITLE
Add ContrastAPI — security intelligence API and MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ START FOR FREE
 - [Hudson Rock Free Cybercrime Intelligence Tools](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools) - Check if a specific domain or email address was compromised by Infostealer infections.
 - [Intelligence Security](https://intelligencesecurity.io/) - Threat intelligence and security information platform.
 - [MITRE ATT&CK](https://attack.mitre.org/) - Knowledge base of adversary tactics and techniques.
+- [ContrastAPI](https://api.contrastcyber.com) - Security intelligence API and MCP server — domain recon, CVE lookup, IP reputation, threat intel, subdomain enumeration, and code security scanning. 23 tools, free, no API key required.
 - [Abuse.ch](https://abuse.ch/) - Fighting malware and botnets with various tracking projects.
 - [URLhaus](https://urlhaus.abuse.ch/) - Share malicious URLs that are being used for malware distribution.
 - [MalwareBazaar](https://bazaar.abuse.ch/) - Share malware samples for research purposes.


### PR DESCRIPTION
Adds ContrastAPI to the Threat Intel section.

- **23 security tools** as REST API + MCP server
- Domain recon, CVE lookup, IP reputation, threat intel, subdomain enumeration, code security
- Free, no API key required
- GitHub: https://github.com/UPinar/contrastapi