### PR TITLE
Update ContrastAPI entry: 23 → 31 tools (v1.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ START FOR FREE
 - [Hudson Rock Free Cybercrime Intelligence Tools](https://www.hudsonrock.com/threat-intelligence-cybercrime-tools) - Check if a specific domain or email address was compromised by Infostealer infections.
 - [Intelligence Security](https://intelligencesecurity.io/) - Threat intelligence and security information platform.
 - [MITRE ATT&CK](https://attack.mitre.org/) - Knowledge base of adversary tactics and techniques.
-- [ContrastAPI](https://api.contrastcyber.com) - Security intelligence API and MCP server — domain recon, CVE lookup, IP reputation, threat intel, subdomain enumeration, and code security scanning. 23 tools, free, no API key required.
+- [ContrastAPI](https://api.contrastcyber.com) - Security intelligence API and MCP server — domain recon, CVE lookup (340K+ with EPSS+KEV), IP threat reports, IOC enrichment, dependency audit, and code security scanning. 31 tools, free, no API key required.
 - [Abuse.ch](https://abuse.ch/) - Fighting malware and botnets with various tracking projects.
 - [URLhaus](https://urlhaus.abuse.ch/) - Share malicious URLs that are being used for malware distribution.
 - [MalwareBazaar](https://bazaar.abuse.ch/) - Share malware samples for research purposes.


### PR DESCRIPTION
Refresh ContrastAPI description after v1.8.0 — now 31 tools (CVE 340K+, dependency audit, IOC enrichment).
Still free, no API key. Release: https://github.com/UPinar/contrastapi/releases/tag/v1.8.0