### PR TITLE
Add Helium MCP - structured bias scores + balanced news synthesis for AI assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,7 @@ the number of views or likes.
 - [Google Alerts](https://www.google.com/alerts) - Monitor the web for interesting new content create an email alert about any topic in mind
 - [Hoaxy: How claims spread online](https://hoaxy.osome.iu.edu/) - Visualize the spread of information on Twitter
 - [Snopes](https://www.snopes.com/?s=) - The definitive fact-checking site and reference source for urban legends, folklore, myths, rumors, and misinformation.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free MCP server giving AI assistants (Claude, Cursor) structured 31-dimension bias scores per article (sensationalism, scapegoating, opinion-vs-fact, AI-authorship probability) across 3.2M+ articles from 5,000+ sources, plus multi-source balanced synthesis.
 - [ReviewMeta](https://reviewmeta.com/) - ReviewMeta analyzes Amazon product reviews and filters out reviews that our algorithm detects may be unnatural.
 - [Verification Handbook](https://datajournalism.com/read/handbook/verification-1) - Need to learn new data skills, increase your data journalism knowledge or advance your career?
 - [Truth or Fiction](https://www.truthorfiction.com/) - Truth or Fiction? – Seeking truth, exposing fiction

--- a/README.md
+++ b/README.md
@@ -1098,7 +1098,7 @@ the number of views or likes.
 - [Google Alerts](https://www.google.com/alerts) - Monitor the web for interesting new content create an email alert about any topic in mind
 - [Hoaxy: How claims spread online](https://hoaxy.osome.iu.edu/) - Visualize the spread of information on Twitter
 - [Snopes](https://www.snopes.com/?s=) - The definitive fact-checking site and reference source for urban legends, folklore, myths, rumors, and misinformation.
-- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free MCP server giving AI assistants (Claude, Cursor) structured 31-dimension bias scores per article (sensationalism, scapegoating, opinion-vs-fact, AI-authorship probability) across 3.2M+ articles from 5,000+ sources, plus multi-source balanced synthesis.
+- [Helium MCP](https://github.com/connerlambden/helium-mcp) - Free MCP server giving AI assistants (Claude, Cursor) structured 31-dimensional bias scores per article (sensationalism, scapegoating, opinion-vs-fact, AI-authorship probability) across 3.2M+ articles from 5,000+ sources, plus multi-source balanced synthesis.
 - [ReviewMeta](https://reviewmeta.com/) - ReviewMeta analyzes Amazon product reviews and filters out reviews that our algorithm detects may be unnatural.
 - [Verification Handbook](https://datajournalism.com/read/handbook/verification-1) - Need to learn new data skills, increase your data journalism knowledge or advance your career?
 - [Truth or Fiction](https://www.truthorfiction.com/) - Truth or Fiction? – Seeking truth, exposing fiction


### PR DESCRIPTION
Adding [Helium MCP](https://github.com/connerlambden/helium-mcp) under the News section.

Free, open MCP (Model Context Protocol) server giving AI assistants (Claude, Cursor) structured analysis on 3.2M+ articles from 5,000+ sources:
- **31 bias dimensions per article**: sensationalism, scapegoating, opinion-vs-fact, AI-authorship probability, credibility, fearfulness, etc.
- `search_balanced_news`: synthesizes coverage of an event across many sources with evidence and probability-weighted potential outcomes
- `get_source_bias`: per-outlet aggregate scores (e.g., 445 articles analyzed for CNN)

Useful for OSINT investigators who want to interrogate framing programmatically inside AI workflows. One-line setup, no signup.

Thanks for considering!