### PR TITLE
Add Crime Brasil under UNIFIED SEARCH

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,6 +595,7 @@ You will find a lot of information related to a domain, a IP Address or to an AS
 <br>
 
 [⇧ Top](#index)
+- [Crime Brasil](https://crimebrasil.com.br) - Open-data platform consolidating Brazilian crime statistics and public records. ~3M geocoded incidents from state police sources (SSP/RS, ISP/RJ, SEJUSP/MG), federal highway accidents (PRF DATATRAN), and urban traffic (EPTC/POA). Free REST API + CSV/Parquet, CC BY 4.0.
 ## PEOPLE
 
 - [IDCrawl](https://www.idcrawl.com/) - People Search a friend, relative, yourself, or someone else you may know (US ONLY).


### PR DESCRIPTION
Adds [Crime Brasil](https://crimebrasil.com.br) under UNIFIED SEARCH — a public-records / crime-data search platform for Brazil. Similar positioning to InfoTracer and IOA already in that section. ~3M geocoded criminal incidents via free REST API, CSV/Parquet, CC BY 4.0. Useful for investigators working on Brazilian leads. Disclosure: I'm the maintainer.