### PR TITLE
Add Crime Brasil under UNIFIED SEARCH (clean diff — re-submit of #101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ You will find a lot of information related to a domain, a IP Address or to an AS
 - [LinkScope](https://github.com/AccentuSoft/LinkScope_Client) - LinkScope allows you to perform online investigations by representing information as discrete pieces of data, called Entities.
 - [IOA](https://www.io-archive.org/) - The Information Operation Archive hosts publicly available and rigorously attributed datapoints from known Information Operations on social media platforms.
 - [ApifyForge](https://apifyforge.com) - 93 MCP intelligence servers and 300+ data tools for automated OSINT. AML screening, sanctions checks (OFAC, OpenSanctions, Interpol), beneficial ownership, corporate due diligence, SEC filings, cybersecurity attack surface analysis. Each server queries 7-18 sources in parallel.
+- [Crime Brasil](https://crimebrasil.com.br/) - Brazilian crime data platform with ~3M geocoded incidents (national + state/municipality/neighborhood drilldowns). Free REST API, CSV/Parquet exports, CC BY 4.0 licensed. Useful for investigators, journalists, and researchers working Brazilian leads.
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
Re-submitting after #101 was closed — apologies, that previous PR had a messy 2,302-line diff because my local editor normalized the whole file's line endings. This PR is a clean **single-line addition** under UNIFIED SEARCH, CRLF preserved, no unrelated changes.

### Change

One line appended under `## UNIFIED SEARCH`, right after the existing ApifyForge entry:

```markdown
- [Crime Brasil](https://crimebrasil.com.br/) - Brazilian crime data platform with ~3M geocoded incidents (national + state/municipality/neighborhood drilldowns). Free REST API, CSV/Parquet exports, CC BY 4.0 licensed. Useful for investigators, journalists, and researchers working Brazilian leads.
```

### Contributing checklist

- [x] Link verified live (200 OK) — `markdown-link-check` passes on the new line
- [x] Relevant to OSINT — public-records / crime-data search for Brazilian leads, same positioning as InfoTracer and IOA already in the section
- [x] Not already in the list
- [x] Format matches surrounding entries (`- [Name](url) - Description.`)
- [x] Placed in the most appropriate section (UNIFIED SEARCH, where multi-source investigative search tools live)

### Disclosure

I maintain crimebrasil.com.br. The dataset + REST API are free, no auth required, CC BY 4.0 licensed. No affiliate or paywall.

Thanks for the nudge on the first PR — sorry again for wasting your time with the wholesale-rewrite diff.