### PR TITLE
Add HackMyIP to Domain / IP / DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1483,6 +1483,7 @@ Enter two images and the difference will show up below
 - [CertGrep](https://certgrep.sh/) - SSL/TLS certificate search and monitoring.
 - [TriNetLayer](https://trinetlayer.com/) - Network layer analysis and IP intelligence.
 - [IPLoop](https://iploop.io) - Residential proxy platform (2M+ IPs, 195+ countries). Route OSINT recon through real residential IPs. Python SDK with 66 site presets.
+- [HackMyIP](https://hackmyip.com/) - Privacy and network intelligence toolkit with IP lookup, DNS lookup, email breach check, port scanner, browser fingerprint, WebRTC leak test, and DNS leak test.
 <br>
 
 [⇧ Top](#index)


### PR DESCRIPTION
## What this PR does

Adds [HackMyIP](https://hackmyip.com/) to the **Domain / IP / DNS** section.

## About the tool

HackMyIP is a free privacy and network intelligence toolkit relevant to OSINT research. It provides:

- IP lookup and geolocation
- DNS lookup
- Email breach check
- Port scanner
- Browser fingerprint detection
- WebRTC leak test
- DNS leak test

## Checklist

- [x] Link is working and verified
- [x] Tool is relevant to OSINT (Domain / IP / DNS category)
- [x] Not a duplicate (verified not already in the list)
- [x] Follows existing entry format: `- [Tool Name](URL) - Description`
- [x] Placed in the appropriate section (Domain / IP / DNS)
- [x] Single-line addition, no other changes to the file
- [x] Free to use, no paywall