### PR TITLE
Add IPASIS to Domain / IP / DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,7 @@ Enter two images and the difference will show up below
 - [WhoisXMLAPI](https://www.whoisxmlapi.com/) - Domain and IP intelligence APIs.
 - [IPinfo](https://ipinfo.io/) - IP address data and geolocation API.
 - [IPQualityScore](https://www.ipqualityscore.com/) - Fraud detection and IP reputation.
+- [IPASIS](https://ipasis.com) - Real-time bot detection and fraud prevention API combining IP reputation, proxy/VPN/Tor detection, and email validation in a single call.
 - [Frostbyte GeoIP API](https://api-catalog-three.vercel.app/services/ip-geolocation-api) - Free IP geolocation API returning country, city, ISP, coordinates, and timezone. 200 free lookups, no signup required.
 - [Frostbyte DNS API](https://api-catalog-three.vercel.app) - DNS record lookup API supporting A, AAAA, MX, NS, TXT, and CNAME queries with WHOIS data.
 - [Netlas.io](https://netlas.io/) - Internet intelligence search for domains, IPs, and certificates.


### PR DESCRIPTION
Adds [IPASIS](https://ipasis.com) to the Domain / IP / DNS section.

IPASIS is a real-time bot detection and fraud prevention API that combines IP reputation, proxy/VPN/Tor detection, and email validation in a single API call. It returns a trust score (0-100) per interaction. Free tier available (1,000 requests/day).

Placed alongside IPQualityScore and IPinfo as it serves a similar IP intelligence use case.