### PR TITLE
Add GetXAPI to TWITTER section

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ You are searching 121 billion records.
 [⇧ Top](#index)
  ## TWITTER
 
+- [GetXAPI](https://www.getxapi.com/) - Twitter / X data API for OSINT collection. Read endpoints (search, profiles, follower graph, mentions, lists, communities, trends) and write endpoints. Bearer-token auth. Public OpenAPI 3.1 spec.
 - [BirdHunt](https://birdhunt.co/) - BirdHunt will show you all tweets within the chosen geographic location
 - [Nitter](https://github.com/zedeus/nitter/) - Alternative Twitter front-end
 - [Twitter Search Engine](https://cse.google.com/cse?cx=5857bab69c8b8e37e) - custom search engine for twitter


### PR DESCRIPTION
Adds GetXAPI under the Twitter section.

GetXAPI is a Twitter / X data API. Read endpoints (search, profiles, follower graph, mentions, lists, communities, trends) + write endpoints (post tweets, like, retweet, follow, DM, articles). Bearer-token auth, public OpenAPI 3.1 spec. Useful for OSINT teams running fixed-budget collection across the X graph.

- Site: https://www.getxapi.com
- Docs: https://docs.getxapi.com
- Spec: https://docs.getxapi.com/openapi.json
- Wikidata: https://www.wikidata.org/wiki/Q139996278