### PR TITLE
Add defend.network to THREAT INTEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,7 @@ START FOR FREE
 [⇧ Top](#index)
  ## THREAT INTEL
 
+- [defend.network](https://defend.network) - Free, no-login cyber threat intelligence with daily threat briefings and weekly vulnerability reports; every CVE cross-checked against NVD and the CISA KEV catalog, structured by threat type, industry, and severity
 - [Threatbutt](https://threatbutt.com/map/) - Threatbutt Internet Hacking Attack Attribution Map
 - [Cyberthreat Real-Time Map](https://cybermap.kaspersky.com/) - cyberthreat real-time attack map of the world
 - [Live Cyber Attack Threat Map](https://www.checkpoint.com/ThreatPortal/livemap.html) - Live cyber threat map


### PR DESCRIPTION
Adds [defend.network](https://defend.network) to the **THREAT INTEL** section.

defend.network is a free, no-login cyber threat intelligence site publishing daily threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog. Content is structured by threat type, industry, and severity, with remediation guidance. An RSS feed is available at https://defend.network/feed.xml.

Thanks for maintaining this list!