### PR TITLE
Add FinalNotes obituary research guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2022,6 +2022,7 @@ about police misconduct in Chicago
 - [SortedByName.com](https://sortedbyname.com/)
 - [Sortedbybirthdate.com](https://sortedbybirthdate.com/)
 - [Cemetery.directory](https://cemetery.directory/)
+- [FinalNotes Obituary Research Guide](https://www.finalnotes.page/obituary-research-guide/) - Guide for finding obituary records, preserving source trails, and using obituary clues in sourced family-history research.
 - [Social Security Death Index](https://stevemorse.org/ssdi/ssdi.html)
 - [FamilySearch’s United States Record Collections](https://stevemorse.org/fhl/websitesunitedstates.html)
 - [Chicago Cook County Genealogy](https://stevemorse.org/vital/cook.html)


### PR DESCRIPTION
Adds the FinalNotes Obituary Research Guide to the Public Records section, next to cemetery, death-index, and genealogy resources. Verified the target URL returns HTTP 200. Note: the repository markdownlint and full link-check commands currently report many pre-existing README-wide failures, so this PR is scoped to the one added resource line.