### PR TITLE
Add IPok to DOMAIN / IP / DNS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1555,6 +1555,7 @@ Enter two images and the difference will show up below
 - [IPinfo](https://ipinfo.io/) - IP address data and geolocation API.
 - [IPQualityScore](https://www.ipqualityscore.com/) - Fraud detection and IP reputation.
 - [IPASIS](https://ipasis.com) - Real-time bot detection and fraud prevention API combining IP reputation, proxy/VPN/Tor detection, and email validation in a single call.
+- [IPok](https://ipok.io/) - Free, no-login IP reputation and "purity" checker that aggregates up to 8 risk/reputation sources and shows each source's verdict separately, classifies residential vs datacenter, profiles /24 C-block neighbors, and detects your real exit IP. Open-source CLI and Chrome extension available.
 - [Frostbyte GeoIP API](https://api-catalog-three.vercel.app/services/ip-geolocation-api) - Free IP geolocation API returning country, city, ISP, coordinates, and timezone. 200 free lookups, no signup required.
 - [Frostbyte DNS API](https://api-catalog-three.vercel.app) - DNS record lookup API supporting A, AAAA, MX, NS, TXT, and CNAME queries with WHOIS data.
 - [Netlas.io](https://netlas.io/) - Internet intelligence search for domains, IPs, and certificates.


### PR DESCRIPTION
Adds IPok to the DOMAIN / IP / DNS section. IPok is a free, no-login web tool that checks an IP's reputation by aggregating up to eight risk/reputation sources and displaying each source's verdict individually rather than as a single opaque score, alongside residential-vs-datacenter classification and /24 neighbor profiling. It complements the IP-reputation entries already in this section (IPVoid, IPQualityScore, IPASIS) by exposing per-source results, and also ships an open-source CLI (MIT) and a Chrome extension. Link verified.