### PR TITLE
Add insto to Instagram section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1024,6 +1024,7 @@ the number of views or likes.
 - [Instagram User ID](https://commentpicker.com/instagram-user-id.php) - Find any Instagram User ID by Instagram username.
 - [instalooter](https://pypi.org/project/instalooter/) - InstaLooter is a program that can download any picture or video associated from an Instagram profile, without any API access
 - [instaloader](https://pypi.org/project/instaloader/) - Download pictures (or videos) along with their captions and other metadata from Instagram.
+- [insto](https://github.com/subzeroid/insto) - Interactive Instagram OSINT CLI (REPL + one-shot) with watch/diff snapshots and Maltego-ready CSV/JSON export; pluggable HikerAPI/aiograpi backends.
 - [osi.ig](https://github.com/th3unkn0n/osi.ig) - Information Gathering Instagram.
 - [Osintgram](https://github.com/Datalux/Osintgram) - Osintgram is a OSINT tool on Instagram. It offers an interactive shell to perform analysis on Instagram account of any users by its nickname
 - [SoIG](https://github.com/yezz123/SoIG) - OSINT Tool gets a range of information from an Instagram account


### PR DESCRIPTION
Adds **insto** to the Instagram section.

[insto](https://github.com/subzeroid/insto) is an interactive Instagram OSINT CLI (REPL + one-shot mode): profile / posts / stories / followers / tagged / hashtag / search lookups, watch & diff snapshots to track changes over time, and Maltego-ready CSV + versioned JSON export. MIT-licensed, on PyPI (`pip install insto`), actively maintained.

It complements the existing CLI tools already in this section (Osintgram, osi.ig) and is also listed in `jivoi/awesome-osint`. The entry follows the `- [Name](url) - description` format and is placed alphabetically next to `instaloader`. The only added link (`github.com/subzeroid/insto`) is verified working.

_Disclosure: I maintain insto and am affiliated with the HikerAPI / aiograpi backends it can optionally use. insto itself is free and open source — including it here for its standalone value to OSINT analysts, not to promote a paid service._
