### PR TITLE
Add Cerast Intelligence (Attack Surface Discovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2250,6 +2250,7 @@ about police misconduct in Chicago
 - [Criminal IP](https://www.criminalip.io/) - Cyber threat intelligence search engine.
 - [FullHunt](https://fullhunt.io/) - Attack surface discovery and security assessment platform.
 - [Netlas](https://netlas.io/) - Search engine and data analysis platform for internet-connected assets.
+- [Cerast Intelligence](https://search.cerast-intelligence.com/) - Searchable archive of exposed panels and misconfigurations found across domains by continuous internet-wide scanning.
 
 ### Reconnaissance & Enumeration
 - [Amass](https://github.com/owasp-amass/amass) - In-depth attack surface mapping and asset discovery.


### PR DESCRIPTION
Adds **Cerast Intelligence** (https://search.cerast-intelligence.com/) to the *Attack Surface Discovery* section, alongside Shodan/Censys/FOFA/Netlas.

It is a free, searchable archive of exposed panels, misconfigurations, and other bug-class findings discovered across domains via continuous internet-wide scanning. You search by domain name and get back the exposure findings on record for each match.