### PR TITLE
Add CheckLeaked to Breaches and Leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A list of osint tools/websites for pentration testing, Reverse Searching, Red te
 - [WhiteIntel](https://whiteintel.io/) - Dark web data leak search engine for threat intelligence.
 - [PSBDMP](https://psbdmp.ws/) - Pastebin dump search and monitoring platform.
 - [OsintCat](https://www.osintcat.net/) - Check if an email address has been exposed in known data breaches. Covers multiple breach databases with both a web interface and an API.
+- [CheckLeaked](https://checkleaked.cc/) - Check if an email, username or phone appears in a data breach, with the sources shown; free searches, developer API and Telegram/Discord bots.
   
 ## Basic OSINT
 Data Leak, scam, username, domain, social


### PR DESCRIPTION
Adds **CheckLeaked** ([checkleaked.cc](https://checkleaked.cc/)) to the **Breaches and Leaks** section.

Look up an email, username or phone number and see whether — and in which breaches — it appears, with the sources shown. Free searches, a developer REST API, and Telegram/Discord bots. Fits alongside the existing Dehashed, HaveIBeenPwned and LeakCheck entries.

Disclosure: I'm affiliated with CheckLeaked.