### PR TITLE
Add CryptoAML to Blockchain / Crypto Investigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2132,6 +2132,7 @@ about police misconduct in Chicago
 - [Chainalysis](https://www.chainalysis.com/) - Blockchain data platform for investigators.
 - [Elliptic](https://www.elliptic.co/) - Crypto compliance and investigation tools.
 - [Crystal Blockchain](https://crystalblockchain.com/) - Blockchain analytics platform.
+- [CryptoAML](https://cryptoaml.ai) - Free multi-chain AML wallet screening via Telegram bot ([@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot)) and web. Screens against OFAC/UN/EU sanctions, darknet markets, and mixers across 30+ chains, no registration required.
 - [OXT.me](https://oxt.me/) - Bitcoin blockchain explorer with analysis tools.
 - [WalletExplorer](https://www.walletexplorer.com/) - Bitcoin wallet tracking and analysis.
 - [BTC Parser](https://btcparser.com/) - Bitcoin transaction analysis tool.


### PR DESCRIPTION
## What was added

Adding [CryptoAML](https://cryptoaml.ai) to the Blockchain / Crypto Investigation section, alongside Chainalysis, Elliptic, and Crystal Blockchain.

**CryptoAML** is a free AML wallet screening tool:
- Available as a Telegram bot ([@cryptoamlscan_bot](https://t.me/cryptoamlscan_bot)) and web interface (cryptoaml.ai)
- Screens against OFAC, UN, and EU sanctions lists, darknet markets, and mixers
- Covers 30+ chains (BTC, ETH, TRON, BNB Chain, and more)
- No registration required

## Why it's valuable

Fills the gap between full manual investigation platforms (Chainalysis/Elliptic, enterprise-only) and a quick free check anyone can run before receiving a payment or during a preliminary OSINT pass.

Verified the link works and it is not already listed. Single link added, following the existing `- [Name](url) - Description.` format.