### PR TITLE
Add Fylings — African company registries (BUSINESS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1931,6 +1931,7 @@ Enter two images and the difference will show up below
 - [Global Brownbook](https://www.brownbook.net/) - global business listing database
 - [list-org](https://www.list-org.com/) - Basic information about any Russian legal entity or entrepreneur
 - [OpenCorporates](https://opencorporates.com/) - Fresh, standardized, auditable information direct from official primary sources across 140+ jurisdictions — all underpinned by our Legal-Entity Data Principles and world-leading expertise in legal-entity data.
+- [Fylings](https://www.fylings.com/) - Free company-intelligence platform for Africa: search 1.5M+ companies across 18+ official national registries (Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM and more), with the official registry source and a last-verified date on every record. Beneficial ownership, government-contract awards and sanctions screening included. Free API + MCP server.
 - [ICIJ Offshore Leaks Database](https://offshoreleaks.icij.org/) - Find out who's behind more than 810,000 offshore companies, foundations and trusts from the Pandora Papers, Paradise Papers, Bahamas Leaks, Panama Papers and Offshore Leaks investigations.
 - [Crunchbase](https://www.crunchbase.com/) - Discover innovative companies and the people behind them.
 - [PitchBook](https://pitchbook.com/) - Private capital market data and research.


### PR DESCRIPTION
Adds [Fylings](https://www.fylings.com/) to the **BUSINESS** section, next to OpenCorporates.

**Why it fits:** the section covers Companies House (UK), list-org (Russia) and OpenCorporates (global), but Africa is thin. Fylings aggregates 18+ official African national registries — Nigeria's CAC, Tanzania's BRELA, Mauritius's CBRD, Senegal's RCCM and others — into one free search.

**Useful for investigators:**
- Every record shows its official registry source and a last-verified date
- Beneficial-ownership / PSC data
- Government-contract awards and sanctions screening
- Free to use, no signup for search; public API and MCP server available

Link verified working. One line added, no other changes.